### PR TITLE
Fixed bug in sorting & innerText introduced by chrome 70

### DIFF
--- a/addon/components/model-picker.js
+++ b/addon/components/model-picker.js
@@ -72,7 +72,9 @@ export default Component.extend(formFieldOptions, {
         list = list.toArray();
       }
 
-      list = list.sort(sortFunction);
+      if (sortFunction) {
+        list.sort(sortFunction);
+      }
       return groupBy(list, groupLabelPath);
     });
   }).restartable(),

--- a/tests/integration/components/auto-complete-test.js
+++ b/tests/integration/components/auto-complete-test.js
@@ -65,7 +65,7 @@ module('Integration | Component | {{auto-complete}}', function(hooks) {
 
     await clickTrigger();
 
-    this.set('sortFunction', (a, b) => a.foo > b.foo);
+    this.set('sortFunction', (a, b) => a.foo > b.foo ? 1 : a.foo < b.foo ? -1 : 0);
 
     await clickTrigger();
     $items = $('.ember-power-select-dropdown li');
@@ -343,7 +343,7 @@ module('Integration | Component | {{auto-complete}}', function(hooks) {
         this.set('selection', option);
       });
 
-      assert.equal(getSelected()[0].innerText.indexOf('b'), 0,
+      assert.equal(getSelected()[0].innerText.trim().indexOf('b'), 0,
                    'change selected item');
 
       run(() => {

--- a/tests/integration/components/model-picker-test.js
+++ b/tests/integration/components/model-picker-test.js
@@ -262,7 +262,7 @@ module('Integration | Component | {{model-picker}}', function(hooks) {
                                    searchProperty="name"}}`);
 
     let $selectedOption = getSelected();
-    assert.equal($selectedOption[0].innerText.indexOf('bar test'), 0);
+    assert.equal($selectedOption[0].innerText.trim().indexOf('bar test'), 0);
     await clickTrigger();
   });
 


### PR DESCRIPTION
The implementation of `Array.sort()` and `Node.innerText` has been changed in the most recent Chrome update. This has introduced a bug in our auto-complete component and in our component tests